### PR TITLE
[JENKINS-36238] UUID on messages

### DIFF
--- a/src/main/java/org/jenkins/pubsub/EventFilter.java
+++ b/src/main/java/org/jenkins/pubsub/EventFilter.java
@@ -28,4 +28,10 @@ package org.jenkins.pubsub;
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>
  */
 public final class EventFilter extends Message<EventFilter> {
+    EventFilter() {
+        super();
+        // Remove the UUID so as to prevent it from interfeering
+        // with the filter containsAll check.
+        remove(EventProps.Jenkins.jenkins_event_uuid.name());
+    }
 }

--- a/src/main/java/org/jenkins/pubsub/EventProps.java
+++ b/src/main/java/org/jenkins/pubsub/EventProps.java
@@ -58,6 +58,10 @@ public interface EventProps {
          */
         jenkins_event,
         /**
+         * The event UUID.
+         */
+        jenkins_event_uuid,
+        /**
          * Jenkins domain object type.
          */
         jenkins_object_type,

--- a/src/main/java/org/jenkins/pubsub/GuavaPubsubBus.java
+++ b/src/main/java/org/jenkins/pubsub/GuavaPubsubBus.java
@@ -26,7 +26,6 @@ package org.jenkins.pubsub;
 import com.google.common.eventbus.AsyncEventBus;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
-import hudson.model.User;
 import hudson.security.ACL;
 import hudson.util.CopyOnWriteMap;
 import jenkins.model.Jenkins;
@@ -80,8 +79,8 @@ public final class GuavaPubsubBus extends PubsubBus {
     }
 
     @Override
-    public void subscribe(@Nonnull String channelName, @Nonnull ChannelSubscriber subscriber, @Nonnull User user, @CheckForNull EventFilter eventFilter) {
-        GuavaSubscriber guavaSubscriber = new GuavaSubscriber(subscriber, user, eventFilter);
+    public void subscribe(@Nonnull String channelName, @Nonnull ChannelSubscriber subscriber, @Nonnull Authentication authentication, @CheckForNull EventFilter eventFilter) {
+        GuavaSubscriber guavaSubscriber = new GuavaSubscriber(subscriber, authentication, eventFilter);
         EventBus channelBus = getChannelBus(channelName);
         channelBus.register(guavaSubscriber);
         subscribers.put(subscriber, guavaSubscriber);
@@ -118,14 +117,12 @@ public final class GuavaPubsubBus extends PubsubBus {
         private Authentication authentication;
         private final EventFilter eventFilter;
 
-        public GuavaSubscriber(@Nonnull ChannelSubscriber subscriber, User user, EventFilter eventFilter) {
+        public GuavaSubscriber(@Nonnull ChannelSubscriber subscriber, Authentication authentication, EventFilter eventFilter) {
             this.subscriber = subscriber;
-            if (user != null) {
-                if (user.getId().equalsIgnoreCase("anonymous")) {
-                    this.authentication = Jenkins.ANONYMOUS;
-                } else {
-                    this.authentication = user.impersonate();
-                }
+            if (authentication != null) {
+                this.authentication = authentication;
+            } else {
+                this.authentication = Jenkins.ANONYMOUS;
             }
             this.eventFilter = eventFilter;
         }

--- a/src/main/java/org/jenkins/pubsub/Message.java
+++ b/src/main/java/org/jenkins/pubsub/Message.java
@@ -34,6 +34,7 @@ import java.io.Writer;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * {@link PubsubBus} message instance.
@@ -72,6 +73,8 @@ public abstract class Message<T extends Message> extends Properties {
      * Create a plain message instance.
      */
     Message() {
+        // Add a UUID to the event message.
+        this.set(EventProps.Jenkins.jenkins_event_uuid, UUID.randomUUID().toString());
     }
 
     /**
@@ -197,6 +200,14 @@ public abstract class Message<T extends Message> extends Properties {
     public T setEventName(Enum name) {
         set(EventProps.Jenkins.jenkins_event, name.name());
         return (T) this;
+    }
+    
+    /**
+     * Get the event UUID for the message.
+     * @return The event UUID for the message, or {@code null} if none set.
+     */
+    public String getEventUUID() {
+        return get(EventProps.Jenkins.jenkins_event_uuid);
     }
     
     /**

--- a/src/main/java/org/jenkins/pubsub/PubsubBus.java
+++ b/src/main/java/org/jenkins/pubsub/PubsubBus.java
@@ -25,8 +25,8 @@ package org.jenkins.pubsub;
 
 import hudson.ExtensionList;
 import hudson.ExtensionPoint;
-import hudson.model.User;
 import hudson.security.AccessControlled;
+import org.acegisecurity.Authentication;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -115,14 +115,14 @@ public abstract class PubsubBus implements ExtensionPoint {
      * Subscribe to events on the specified event channel.
      * @param channelName The channel name.
      * @param subscriber  The subscriber instance that will receive the events.
-     * @param user        The Jenkins user associated with the subscriber.  
+     * @param authentication The authentication to which the subscription is associated.  
      * @param eventFilter A message filter, or {@code null} if no filtering is to be applied.
      *                    This tells the bus to only forward messages that match the properties
      *                    (names and values) specified in the filter.
      */
     public abstract void subscribe(@Nonnull String channelName,
                                        @Nonnull ChannelSubscriber subscriber,
-                                       @Nonnull User user,
+                                       @Nonnull Authentication authentication,
                                        @CheckForNull EventFilter eventFilter);
 
     /**

--- a/src/test/java/org/jenkins/pubsub/GuavaPubsubBusItemTest.java
+++ b/src/test/java/org/jenkins/pubsub/GuavaPubsubBusItemTest.java
@@ -44,8 +44,8 @@ public class GuavaPubsubBusItemTest {
         MockSubscriber subs2 = new MockSubscriber();
 
         // Subscribers ...
-        bus.subscribe("jenkins.job", subs1, alice, null);
-        bus.subscribe("jenkins.slave", subs2, alice, null);
+        bus.subscribe("jenkins.job", subs1, alice.impersonate(), null);
+        bus.subscribe("jenkins.slave", subs2, alice.impersonate(), null);
         
         // Publish ...
         jobPublisher.publish(new SimpleMessage().set("joba", "joba"));
@@ -66,7 +66,7 @@ public class GuavaPubsubBusItemTest {
         MockSubscriber subs = new MockSubscriber();
 
         // Subscribers ...
-        bus.subscribe("jenkins.job", subs, alice, new EventFilter().set("joba", "joba"));
+        bus.subscribe("jenkins.job", subs, alice.impersonate(), new EventFilter().set("joba", "joba"));
         
         // Publish ...
         jobPublisher.publish(new SimpleMessage().set("joba", "joba")); // Should get delivered
@@ -84,7 +84,7 @@ public class GuavaPubsubBusItemTest {
         ChannelPublisher jobPublisher = bus.publisher("jenkins.job");
         MockSubscriber subs = new MockSubscriber();
 
-        bus.subscribe("jenkins.job", subs, alice, null);
+        bus.subscribe("jenkins.job", subs, alice.impersonate(), null);
         
         jobPublisher.publish(new ItemMessage(new MockItem().setACL(MockItem.YES_ACL)).set("joba", "1"));
         jobPublisher.publish(new ItemMessage(new MockItem().setACL(MockItem.YES_ACL)).set("joba", "2"));

--- a/src/test/java/org/jenkins/pubsub/GuavaPubsubBusRunTest.java
+++ b/src/test/java/org/jenkins/pubsub/GuavaPubsubBusRunTest.java
@@ -54,8 +54,8 @@ public class GuavaPubsubBusRunTest {
             MockSubscriber bobSubs = new MockSubscriber();
 
             // alice and bob both subscribe to job event messages ...
-            bus.subscribe(Events.JobChannel.NAME, aliceSubs, alice, null);
-            bus.subscribe(Events.JobChannel.NAME, bobSubs, bob, null);
+            bus.subscribe(Events.JobChannel.NAME, aliceSubs, alice.impersonate(), null);
+            bus.subscribe(Events.JobChannel.NAME, bobSubs, bob.impersonate(), null);
 
             // Create a job as Alice and restrict it to her
             // bob etc should not be able to see it.

--- a/src/test/java/org/jenkins/pubsub/MessageTest.java
+++ b/src/test/java/org/jenkins/pubsub/MessageTest.java
@@ -42,6 +42,12 @@ public class MessageTest {
     @Test
     public void test_toJSON() {
         Message message = new SimpleMessage().set("a", "aVal");
+
+        // Check that the message has a UUID. Then remove it
+        // so we can do a check on the rest of the content.
+        assertTrue(message.getEventUUID() != null);
+        message.remove(EventProps.Jenkins.jenkins_event_uuid.name());
+
         assertEquals("{\"a\":\"aVal\"}", message.toJSON());
         assertEquals("{\"a\":\"aVal\"}", message.toString());
     }


### PR DESCRIPTION
Required for [JENKINS-36238](https://issues.jenkins-ci.org/browse/JENKINS-36238).

Also changed to use `Authentication` on subscribe Vs a `User`.