### PR TITLE
Urgh - thread safety

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pubsub/listeners/SyncQueueListener.java
+++ b/src/main/java/org/jenkinsci/plugins/pubsub/listeners/SyncQueueListener.java
@@ -77,7 +77,7 @@ public class SyncQueueListener extends QueueListener {
     //
     private static BlockingQueue<Queue.LeftItem> queueTaskLeftPublishQueue = new LinkedBlockingQueue<>();
     private static BlockingQueue<Queue.LeftItem> tryLaterQueueTaskLeftQueue = new LinkedBlockingQueue<>(); // see comment above
-    private static boolean stopTaskLeftPublishing = false;
+    private static volatile boolean stopTaskLeftPublishing = false;
     private static final long POLL_TIMEOUT_MILLIS = 1000;
 
     static {


### PR DESCRIPTION
the thread was never guaranteed to terminate as the variable could be cached as it was not volatile.
