### PR TITLE
Revert "add two new props for organization folder indexing"

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pubsub/EventProps.java
+++ b/src/main/java/org/jenkinsci/plugins/pubsub/EventProps.java
@@ -106,14 +106,6 @@ public interface EventProps {
          */
         job_multibranch_indexing_result,
         /**
-         * Organization folder job indexing status.
-         */
-        job_orgfolder_indexing_status,
-        /**
-         * Organization folder job indexing result.
-         */
-        job_orgfolder_indexing_result,
-        /**
          * Job run Queue Id.
          * <p>
          * This is how you correlate between Job Queue tasks and the Runs


### PR DESCRIPTION
Reverts jenkinsci/pubsub-light-module#8

@tfennelly per discussion with @michaelneale , we agreed that it probably doesn't make sense to define these new blueocean-specific event props within the `pubsub-light-module`... but rather within the plugin itself that's enriching the message. I updated the related PR accordingly here:  jenkinsci/blueocean-plugin#810