### PR TITLE
Fix default message prop setting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
   
   <artifactId>pubsub-light</artifactId>
-  <version>1.12-beta-2-SNAPSHOT</version>
+  <version>1.12-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Jenkins Pub-Sub "light" Bus</name>

--- a/src/main/java/org/jenkinsci/plugins/pubsub/EventFilter.java
+++ b/src/main/java/org/jenkinsci/plugins/pubsub/EventFilter.java
@@ -29,10 +29,8 @@ package org.jenkinsci.plugins.pubsub;
  */
 public final class EventFilter extends Message<EventFilter> {
     EventFilter() {
-        super();
-        // Remove the timestamp and UUID so as to prevent it from interfeering
-        // with the filter containsAll check.
-        remove(EventProps.Jenkins.jenkins_event_timestamp.name());
-        remove(EventProps.Jenkins.jenkins_event_uuid.name());
+        // Don't set any of the "default" properties. The filter should start "clean",
+        // adding the filtering properties after construction.
+        super(false);
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/pubsub/Message.java
+++ b/src/main/java/org/jenkinsci/plugins/pubsub/Message.java
@@ -91,11 +91,22 @@ public abstract class Message<T extends Message> extends Properties {
             instanceRootUrl = null;
         }
     }
-    
+
     /**
-     * Create a plain message instance.
+     * Create a plain message instance, with default properties set.
      */
     Message() {
+        this(true);
+    }
+
+    /**
+     * Create a plain message instance.
+     * @param setDefaultProperties Set the default properties.
+     */
+    Message(boolean setDefaultProperties) {
+        if (!setDefaultProperties) {
+            return;
+        }
         
         // Some properties to identify the origin of the event.
         if (instanceRootUrl != null) {

--- a/src/main/java/org/jenkinsci/plugins/pubsub/Message.java
+++ b/src/main/java/org/jenkinsci/plugins/pubsub/Message.java
@@ -76,6 +76,7 @@ public abstract class Message<T extends Message> extends Properties {
 
     private static final Jenkins jenkins = Jenkins.getInstanceOrNull();
     private static final String instanceIdentity;
+    private static final String instanceRootUrl;
 
     static {
         if (jenkins != null) {
@@ -84,8 +85,10 @@ public abstract class Message<T extends Message> extends Properties {
             InstanceIdentity identity = InstanceIdentity.get();
             RSAPublicKey key = identity.getPublic();
             instanceIdentity = new String(Base64.encodeBase64(key.getEncoded()), Charset.forName("UTF-8"));
+            instanceRootUrl = jenkins.getRootUrl();
         } else {
             instanceIdentity = null;
+            instanceRootUrl = null;
         }
     }
     
@@ -95,8 +98,8 @@ public abstract class Message<T extends Message> extends Properties {
     Message() {
         
         // Some properties to identify the origin of the event.
-        if (jenkins != null) {
-            this.set(EventProps.Jenkins.jenkins_instance_url, jenkins.getRootUrl());
+        if (instanceRootUrl != null) {
+            this.set(EventProps.Jenkins.jenkins_instance_url, instanceRootUrl);
         }
         
         // Add an event message timestamp.

--- a/src/test/java/org/jenkinsci/plugins/pubsub/EventFilterTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pubsub/EventFilterTest.java
@@ -1,0 +1,16 @@
+package org.jenkinsci.plugins.pubsub;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class EventFilterTest {
+
+    @Test
+    public void test_no_default_props() {
+        // A Message should have default props set on it.
+        assertTrue(new SimpleMessage().size() > 0);
+        // But an EventFilter should not.
+        assertTrue(new EventFilter().size() == 0);
+    }
+}


### PR DESCRIPTION
# Description

Fixing the cause of the recent BO failure.

Subscription `EventFilter` instances were getting created with a `jenkins_instance_url` + there was a problem with how that was getting set wrt `Jenkins.getRootUrl()` returning `null` in some circumstances.
